### PR TITLE
C++ compatibility changes

### DIFF
--- a/Source/BCEditor.Editor.Caret.pas
+++ b/Source/BCEditor.Editor.Caret.pas
@@ -10,9 +10,6 @@ uses
 type
   TBCEditorCaret = class(TPersistent)
   type
-    TChangedEvent = procedure(ASender: TObject; X, Y: Integer) of object;
-    TOptions = set of TBCEditorCaretOption;
-
     TStyles = class(TPersistent)
     strict private
       FInsert: TBCEditorCaretStyle;
@@ -81,9 +78,6 @@ type
 
     TMultiEdit = class(TPersistent)
     type
-      TOptions = set of TBCEditorCaretMultiEditOption;
-
-
       TColors = class(TPersistent)
       strict private
         FBackground: TColor;
@@ -102,12 +96,12 @@ type
       FColors: TBCEditorCaret.TMultiEdit.TColors;
       FEnabled: Boolean;
       FOnChange: TNotifyEvent;
-      FOptions: TBCEditorCaret.TMultiEdit.TOptions;
+      FOptions: TBCEditorCaretMultiEditOptions;
       FStyle: TBCEditorCaretStyle;
       procedure DoChange;
       procedure SetColors(AValue: TBCEditorCaret.TMultiEdit.TColors);
       procedure SetEnabled(AValue: Boolean);
-      procedure SetOptions(const AValue: TBCEditorCaret.TMultiEdit.TOptions);
+      procedure SetOptions(const AValue: TBCEditorCaretMultiEditOptions);
       procedure SetStyle(const AValue: TBCEditorCaretStyle);
     public
       constructor Create;
@@ -116,7 +110,7 @@ type
     published
       property Colors: TBCEditorCaret.TMultiEdit.TColors read FColors write SetColors;
       property Enabled: Boolean read FEnabled write SetEnabled default True;
-      property Options: TBCEditorCaret.TMultiEdit.TOptions read FOptions write SetOptions default DefaultOptions;
+      property Options: TBCEditorCaretMultiEditOptions read FOptions write SetOptions default DefaultOptions;
       property Style: TBCEditorCaretStyle read FStyle write SetStyle default csVerticalLine;
       property OnChange: TNotifyEvent read FOnChange write FOnChange;
     end;
@@ -128,14 +122,14 @@ type
     FNonBlinking: TBCEditorCaret.TNonBlinking;
     FOffsets: TBCEditorCaret.TOffsets;
     FOnChange: TNotifyEvent;
-    FOptions: TOptions;
+    FOptions: TBCEditorCaretOptions;
     FStyles: TStyles;
     procedure DoChange(ASender: TObject);
     procedure SetMultiEdit(AValue: TBCEditorCaret.TMultiEdit);
     procedure SetNonBlinking(AValue: TBCEditorCaret.TNonBlinking);
     procedure SetOffsets(AValue: TBCEditorCaret.TOffsets);
     procedure SetOnChange(AValue: TNotifyEvent);
-    procedure SetOptions(const AValue: TOptions);
+    procedure SetOptions(const AValue: TBCEditorCaretOptions);
     procedure SetStyles(const AValue: TBCEditorCaret.TStyles);
   public
     constructor Create;
@@ -146,7 +140,7 @@ type
     property MultiEdit: TBCEditorCaret.TMultiEdit read FMultiEdit write SetMultiEdit;
     property NonBlinking: TBCEditorCaret.TNonBlinking read FNonBlinking write SetNonBlinking;
     property Offsets: TBCEditorCaret.TOffsets read FOffsets write SetOffsets;
-    property Options: TOptions read FOptions write SetOptions default DefaultOptions;
+    property Options: TBCEditorCaretOptions read FOptions write SetOptions default DefaultOptions;
     property Styles: TBCEditorCaret.TStyles read FStyles write SetStyles;
     property OnChange: TNotifyEvent read FOnChange write SetOnChange;
   end;
@@ -395,7 +389,7 @@ begin
   end;
 end;
 
-procedure TBCEditorCaret.TMultiEdit.SetOptions(const AValue: TBCEditorCaret.TMultiEdit.TOptions);
+procedure TBCEditorCaret.TMultiEdit.SetOptions(const AValue: TBCEditorCaretMultiEditOptions);
 begin
   if FOptions <> AValue then
   begin
@@ -490,7 +484,7 @@ begin
     Exclude(FOptions, AOption);
 end;
 
-procedure TBCEditorCaret.SetOptions(const AValue: TOptions);
+procedure TBCEditorCaret.SetOptions(const AValue: TBCEditorCaretOptions);
 begin
   if FOptions <> AValue then
   begin

--- a/Source/BCEditor.Editor.CodeFolding.pas
+++ b/Source/BCEditor.Editor.CodeFolding.pas
@@ -8,13 +8,61 @@ uses
   BCEditor.Types, BCEditor.Consts, BCEditor.Editor.Glyph;
 
 type
+    TChangeEvent = procedure(Event: TBCEditorCodeFoldingChanges) of object;
+    TRegions = array of Pointer;
+    TRegionItem = class(TCollectionItem)
+      strict private
+        FBeginWithBreakChar: Boolean;
+        FBreakCharFollows: Boolean;
+        FBreakIfNotFoundBeforeNextRegion: string;
+        FCloseAtNextToken: Boolean;
+        FCloseToken: string;
+        FCloseTokenBeginningOfLine: Boolean;
+        FCloseTokenLength: Integer;
+        FNoSubs: Boolean;
+        FOpenIsClose: Boolean;
+        FOpenToken: string;
+        FOpenTokenBeginningOfLine: Boolean;
+        FOpenTokenBreaksLine: Boolean;
+        FOpenTokenCanBeFollowedBy: string;
+        FOpenTokenEnd: string;
+        FOpenTokenLength: Integer;
+        FParentRegionItem: TRegionItem;
+        FSharedClose: Boolean;
+        FShowGuideLine: Boolean;
+        FSkipIfFoundAfterOpenTokenArray: TBCEditorArrayOfString;
+        FSkipIfFoundAfterOpenTokenArrayCount: Integer;
+        FTokenEndIsPreviousLine: Boolean;
+        procedure SetSkipIfFoundAfterOpenTokenArrayCount(const AValue: Integer);
+      public
+        constructor Create(ACollection: TCollection); override;
+        property BeginWithBreakChar: Boolean read FBeginWithBreakChar write FBeginWithBreakChar;
+        property BreakCharFollows: Boolean read FBreakCharFollows write FBreakCharFollows default True;
+        property BreakIfNotFoundBeforeNextRegion: string read FBreakIfNotFoundBeforeNextRegion write FBreakIfNotFoundBeforeNextRegion;
+        property CloseAtNextToken: Boolean read FCloseAtNextToken write FCloseAtNextToken;
+        property CloseToken: string read FCloseToken write FCloseToken;
+        property CloseTokenBeginningOfLine: Boolean read FCloseTokenBeginningOfLine write FCloseTokenBeginningOfLine default False;
+        property CloseTokenLength: Integer read FCloseTokenLength write FCloseTokenLength;
+        property NoSubs: Boolean read FNoSubs write FNoSubs default False;
+        property OpenIsClose: Boolean read FOpenIsClose write FOpenIsClose default False;
+        property OpenToken: string read FOpenToken write FOpenToken;
+        property OpenTokenBeginningOfLine: Boolean read FOpenTokenBeginningOfLine write FOpenTokenBeginningOfLine default False;
+        property OpenTokenBreaksLine: Boolean read FOpenTokenBreaksLine write FOpenTokenBreaksLine default False;
+        property OpenTokenCanBeFollowedBy: string read FOpenTokenCanBeFollowedBy write FOpenTokenCanBeFollowedBy;
+        property OpenTokenEnd: string read FOpenTokenEnd write FOpenTokenEnd;
+        property OpenTokenLength: Integer read FOpenTokenLength write FOpenTokenLength;
+        property ParentRegionItem: TRegionItem read FParentRegionItem write FParentRegionItem;
+        property SharedClose: Boolean read FSharedClose write FSharedClose default False;
+        property ShowGuideLine: Boolean read FShowGuideLine write FShowGuideLine default True;
+        property SkipIfFoundAfterOpenTokenArray: TBCEditorArrayOfString read FSkipIfFoundAfterOpenTokenArray write FSkipIfFoundAfterOpenTokenArray;
+        property SkipIfFoundAfterOpenTokenArrayCount: Integer read FSkipIfFoundAfterOpenTokenArrayCount write SetSkipIfFoundAfterOpenTokenArrayCount;
+        property TokenEndIsPreviousLine: Boolean read FTokenEndIsPreviousLine write FTokenEndIsPreviousLine default False;
+      end;
+
   TBCEditorCodeFolding = class(TPersistent)
   type
     TAllRanges = class;
     TSkipRegions = class;
-
-    TOptions = set of TBCEditorCodeFoldingOption;
-    TChangeEvent = procedure(Event: TBCEditorCodeFoldingChanges) of object;
 
     TColors = class(TPersistent)
     strict private
@@ -46,57 +94,6 @@ type
     end;
 
     TRegion = class(TCollection)
-    type
-
-      TItem = class(TCollectionItem)
-      strict private
-        FBeginWithBreakChar: Boolean;
-        FBreakCharFollows: Boolean;
-        FBreakIfNotFoundBeforeNextRegion: string;
-        FCloseAtNextToken: Boolean;
-        FCloseToken: string;
-        FCloseTokenBeginningOfLine: Boolean;
-        FCloseTokenLength: Integer;
-        FNoSubs: Boolean;
-        FOpenIsClose: Boolean;
-        FOpenToken: string;
-        FOpenTokenBeginningOfLine: Boolean;
-        FOpenTokenBreaksLine: Boolean;
-        FOpenTokenCanBeFollowedBy: string;
-        FOpenTokenEnd: string;
-        FOpenTokenLength: Integer;
-        FParentRegionItem: TBCEditorCodeFolding.TRegion.TItem;
-        FSharedClose: Boolean;
-        FShowGuideLine: Boolean;
-        FSkipIfFoundAfterOpenTokenArray: TBCEditorArrayOfString;
-        FSkipIfFoundAfterOpenTokenArrayCount: Integer;
-        FTokenEndIsPreviousLine: Boolean;
-        procedure SetSkipIfFoundAfterOpenTokenArrayCount(const AValue: Integer);
-      public
-        constructor Create(ACollection: TCollection); override;
-        property BeginWithBreakChar: Boolean read FBeginWithBreakChar write FBeginWithBreakChar;
-        property BreakCharFollows: Boolean read FBreakCharFollows write FBreakCharFollows default True;
-        property BreakIfNotFoundBeforeNextRegion: string read FBreakIfNotFoundBeforeNextRegion write FBreakIfNotFoundBeforeNextRegion;
-        property CloseAtNextToken: Boolean read FCloseAtNextToken write FCloseAtNextToken;
-        property CloseToken: string read FCloseToken write FCloseToken;
-        property CloseTokenBeginningOfLine: Boolean read FCloseTokenBeginningOfLine write FCloseTokenBeginningOfLine default False;
-        property CloseTokenLength: Integer read FCloseTokenLength write FCloseTokenLength;
-        property NoSubs: Boolean read FNoSubs write FNoSubs default False;
-        property OpenIsClose: Boolean read FOpenIsClose write FOpenIsClose default False;
-        property OpenToken: string read FOpenToken write FOpenToken;
-        property OpenTokenBeginningOfLine: Boolean read FOpenTokenBeginningOfLine write FOpenTokenBeginningOfLine default False;
-        property OpenTokenBreaksLine: Boolean read FOpenTokenBreaksLine write FOpenTokenBreaksLine default False;
-        property OpenTokenCanBeFollowedBy: string read FOpenTokenCanBeFollowedBy write FOpenTokenCanBeFollowedBy;
-        property OpenTokenEnd: string read FOpenTokenEnd write FOpenTokenEnd;
-        property OpenTokenLength: Integer read FOpenTokenLength write FOpenTokenLength;
-        property ParentRegionItem: TBCEditorCodeFolding.TRegion.TItem read FParentRegionItem write FParentRegionItem;
-        property SharedClose: Boolean read FSharedClose write FSharedClose default False;
-        property ShowGuideLine: Boolean read FShowGuideLine write FShowGuideLine default True;
-        property SkipIfFoundAfterOpenTokenArray: TBCEditorArrayOfString read FSkipIfFoundAfterOpenTokenArray write FSkipIfFoundAfterOpenTokenArray;
-        property SkipIfFoundAfterOpenTokenArrayCount: Integer read FSkipIfFoundAfterOpenTokenArrayCount write SetSkipIfFoundAfterOpenTokenArrayCount;
-        property TokenEndIsPreviousLine: Boolean read FTokenEndIsPreviousLine write FTokenEndIsPreviousLine default False;
-      end;
-
     strict private
       FCloseToken: string;
       FEscapeChar: Char;
@@ -104,29 +101,25 @@ type
       FOpenToken: string;
       FSkipRegions: TSkipRegions;
       FStringEscapeChar: Char;
-      function GetItem(AIndex: Integer): TBCEditorCodeFolding.TRegion.TItem;
+      function GetItem(AIndex: Integer): TRegionItem;
     public
       constructor Create(AItemClass: TCollectionItemClass);
       destructor Destroy; override;
-      function Add(const AOpenToken: string; const ACloseToken: string): TBCEditorCodeFolding.TRegion.TItem;
+      function Add(const AOpenToken: string; const ACloseToken: string): TRegionItem;
       function Contains(const AOpenToken: string; const ACloseToken: string): Boolean;
       property CloseToken: string read FCloseToken write FCloseToken;
       property EscapeChar: Char read FEscapeChar write FEscapeChar default BCEDITOR_NONE_CHAR;
       property FoldTags: Boolean read FFoldTags write FFoldTags default False;
-      property Items[AIndex: Integer]: TBCEditorCodeFolding.TRegion.TItem read GetItem; default;
+      property Items[AIndex: Integer]: TRegionItem read GetItem; default;
       property OpenToken: string read FOpenToken write FOpenToken;
       property SkipRegions: TBCEditorCodeFolding.TSkipRegions read FSkipRegions;
       property StringEscapeChar: Char read FStringEscapeChar write FStringEscapeChar default BCEDITOR_NONE_CHAR;
     end;
 
-    TRegions = array of TRegion;
-
     TSkipRegions = class(TCollection)
     type
 
       TItem = class(TCollectionItem)
-      type
-        TItemType = (ritUnspecified, ritMultiLineString, ritSingleLineString, ritMultiLineComment, ritSingleLineComment);
       strict private
         FCloseToken: string;
         FOpenToken: string;
@@ -164,7 +157,7 @@ type
         FIsExtraTokenFound: Boolean;
         FLastLine: Integer;
         FParentCollapsed: Boolean;
-        FRegionItem: TBCEditorCodeFolding.TRegion.TItem;
+        FRegionItem: TRegionItem;
         FSubCodeFoldingRanges: TRanges;
         FUndoListed: Boolean;
       public
@@ -185,7 +178,7 @@ type
         property IsExtraTokenFound: Boolean read FIsExtraTokenFound write FIsExtraTokenFound default False;
         property LastLine: Integer read FLastLine write FLastLine;
         property ParentCollapsed: Boolean read FParentCollapsed write FParentCollapsed;
-        property RegionItem: TBCEditorCodeFolding.TRegion.TItem read FRegionItem write FRegionItem;
+        property RegionItem: TRegionItem read FRegionItem write FRegionItem;
         property SubCodeFoldingRanges: TRanges read FSubCodeFoldingRanges;
         property UndoListed: Boolean read FUndoListed write FUndoListed default False;
       end;
@@ -198,7 +191,7 @@ type
       constructor Create;
       destructor Destroy; override;
       function Add(AAllCodeFoldingRanges: TAllRanges; ABeginLine, AIndentLevel, AFoldRangeLevel: Integer;
-        ARegionItem: TBCEditorCodeFolding.TRegion.TItem; AEndLine: Integer = 0): TRange;
+        ARegionItem: TRegionItem; AEndLine: Integer = 0): TRange;
       procedure Clear;
       property Count: Integer read GetCount;
       property Items[AIndex: Integer]: TRange read GetItem; default;
@@ -240,8 +233,6 @@ type
 
       TIndicator = class(TPersistent)
       type
-        TOptions = set of TBCEditorCodeFoldingHintIndicatorOption;
-
         TColors = class(TPersistent)
         strict private
           FBackground: TColor;
@@ -272,7 +263,7 @@ type
         FColors: TIndicator.TColors;
         FGlyph: TBCEditorGlyph;
         FMarkStyle: TBCEditorCodeFoldingHintIndicatorMarkStyle;
-        FOptions: TBCEditorCodeFolding.THint.TIndicator.TOptions;
+        FOptions: TBCEditorCodeFoldingHintIndicatorOptions;
         FPadding: TPadding;
         FVisible: Boolean;
         FWidth: Integer;
@@ -285,7 +276,7 @@ type
         property Colors: TIndicator.TColors read FColors write FColors;
         property Glyph: TBCEditorGlyph read FGlyph write SetGlyph;
         property MarkStyle: TBCEditorCodeFoldingHintIndicatorMarkStyle read FMarkStyle write FMarkStyle default imsThreeDots;
-        property Options: TBCEditorCodeFolding.THint.TIndicator.TOptions read FOptions write FOptions default DefaultOptions;
+        property Options: TBCEditorCodeFoldingHintIndicatorOptions read FOptions write FOptions default DefaultOptions;
         property Padding: TPadding read FPadding write FPadding;
         property Visible: Boolean read FVisible write FVisible default True;
         property Width: Integer read FWidth write FWidth default 26;
@@ -322,7 +313,7 @@ type
     FMarkStyle: TBCEditorCodeFoldingMarkStyle;
     FMouseOverHint: Boolean;
     FOnChange: TChangeEvent;
-    FOptions: TOptions;
+    FOptions: TBCEditorCodeFoldingOptions;
     FPadding: Integer;
     FVisible: Boolean;
     FWidth: Integer;
@@ -331,7 +322,7 @@ type
     procedure SetHint(AValue: THint);
     procedure SetMarkStyle(const AValue: TBCEditorCodeFoldingMarkStyle);
     procedure SetOnChange(AValue: TChangeEvent);
-    procedure SetOptions(AValue: TOptions);
+    procedure SetOptions(AValue: TBCEditorCodeFoldingOptions);
     procedure SetPadding(const AValue: Integer);
     procedure SetVisible(const AValue: Boolean);
     procedure SetWidth(AValue: Integer);
@@ -347,7 +338,7 @@ type
     property DelayInterval: Cardinal read FDelayInterval write FDelayInterval default 300;
     property Hint: THint read FHint write SetHint;
     property MarkStyle: TBCEditorCodeFoldingMarkStyle read FMarkStyle write SetMarkStyle default msSquare;
-    property Options: TOptions read FOptions write SetOptions default DefaultOptions;
+    property Options: TBCEditorCodeFoldingOptions read FOptions write SetOptions default DefaultOptions;
     property Padding: Integer read FPadding write SetPadding default 2;
     property Visible: Boolean read FVisible write SetVisible default False;
     property Width: Integer read FWidth write SetWidth default 14;
@@ -452,7 +443,7 @@ end;
 
 { TBCEditorCodeFolding.TRegion.TItem ******************************************}
 
-constructor TBCEditorCodeFolding.TRegion.TItem.Create(ACollection: TCollection);
+constructor TRegionItem.Create(ACollection: TCollection);
 begin
   inherited Create(ACollection);
 
@@ -467,7 +458,7 @@ begin
   FBreakCharFollows := True;
 end;
 
-procedure TBCEditorCodeFolding.TRegion.TItem.SetSkipIfFoundAfterOpenTokenArrayCount(const AValue: Integer);
+procedure TRegionItem.SetSkipIfFoundAfterOpenTokenArrayCount(const AValue: Integer);
 begin
   FSkipIfFoundAfterOpenTokenArrayCount := AValue;
   SetLength(FSkipIfFoundAfterOpenTokenArray, AValue);
@@ -492,9 +483,9 @@ begin
   inherited;
 end;
 
-function TBCEditorCodeFolding.TRegion.Add(const AOpenToken: string; const ACloseToken: string): TItem;
+function TBCEditorCodeFolding.TRegion.Add(const AOpenToken: string; const ACloseToken: string): TRegionItem;
 begin
-  Result := TItem(inherited Add);
+  Result := TRegionItem(inherited Add);
   with Result do
   begin
     OpenToken := AOpenToken;
@@ -507,7 +498,7 @@ end;
 function TBCEditorCodeFolding.TRegion.Contains(const AOpenToken: string; const ACloseToken: string): Boolean;
 var
   LIndex: Integer;
-  LItem: TItem;
+  LItem: TRegionItem;
 begin
   Result := False;
   for LIndex := 0 to Count - 1 do
@@ -518,9 +509,9 @@ begin
   end;
 end;
 
-function TBCEditorCodeFolding.TRegion.GetItem(AIndex: Integer): TItem;
+function TBCEditorCodeFolding.TRegion.GetItem(AIndex: Integer): TRegionItem;
 begin
-  Result := TItem(inherited Items[AIndex]);
+  Result := TRegionItem(inherited Items[AIndex]);
 end;
 
 { TBCEditorCodeFolding.TSkipRegions *******************************************}
@@ -653,7 +644,7 @@ begin
 end;
 
 function TBCEditorCodeFolding.TRanges.Add(AAllCodeFoldingRanges: TAllRanges; ABeginLine, AIndentLevel, AFoldRangeLevel: Integer;
-  ARegionItem: TRegion.TItem; AEndLine: Integer): TRange;
+  ARegionItem: TRegionItem; AEndLine: Integer): TRange;
 begin
   Result := TRange.Create;
   with Result do
@@ -1018,7 +1009,7 @@ begin
     Exclude(FOptions, AOption);
 end;
 
-procedure TBCEditorCodeFolding.SetOptions(AValue: TOptions);
+procedure TBCEditorCodeFolding.SetOptions(AValue: TBCEditorCodeFoldingOptions);
 var
   LRescan: Boolean;
 begin

--- a/Source/BCEditor.Editor.CompletionProposal.PopupWindow.pas
+++ b/Source/BCEditor.Editor.CompletionProposal.PopupWindow.pas
@@ -24,8 +24,8 @@ type
     FItems: TStrings;
     FMargin: Integer;
     FOnCanceled: TNotifyEvent;
-    FOnSelected: TBCEditorCompletionProposal.TSelectedEvent;
-    FOnValidate: TBCEditorCompletionProposal.TValidateEvent;
+    FOnSelected: TSelectedEvent;
+    FOnValidate: TValidateEvent;
     FSelectedLine: Integer;
     FSendToEditor: Boolean;
     FTitleHeight: Integer;
@@ -33,7 +33,7 @@ type
     FTopLine: Integer;
     FValueSet: Boolean;
     function GetItemHeight: Integer;
-    function GetItems: TBCEditorCompletionProposal.TItems;
+    function GetItems: TCompletionItems;
     function GetTitleHeight: Integer;
     function GetVisibleLines: Integer;
     procedure HandleDblClick(ASender: TObject);
@@ -58,10 +58,10 @@ type
     procedure MouseWheel(AShift: TShiftState; AWheelDelta: Integer; AMousePos: TPoint);
     procedure WndProc(var Msg: TMessage); override;
     property CurrentString: string read FCurrentString write SetCurrentString;
-    property Items: TBCEditorCompletionProposal.TItems read GetItems;
+    property Items: TCompletionItems read GetItems;
     property TopLine: Integer read FTopLine write SetTopLine;
     property OnCanceled: TNotifyEvent read FOnCanceled write FOnCanceled;
-    property OnSelected: TBCEditorCompletionProposal.TSelectedEvent read FOnSelected write FOnSelected;
+    property OnSelected: TSelectedEvent read FOnSelected write FOnSelected;
   end;
 
 implementation {***************************************************************}
@@ -169,7 +169,7 @@ var
     LAutoWidthCount: Integer;
     LColumnIndex: Integer;
     LIndex: Integer;
-    LItems: TBCEditorCompletionProposal.TItems;
+    LItems: TCompletionItems;
     LMaxWidth: Integer;
     LProposalColumn: TBCEditorCompletionProposal.TColumns.TColumn;
     LTempWidth: Integer;
@@ -319,7 +319,7 @@ begin
   end;
 end;
 
-function TBCEditorCompletionProposalPopupWindow.GetItems: TBCEditorCompletionProposal.TItems;
+function TBCEditorCompletionProposalPopupWindow.GetItems: TCompletionItems;
 begin
   Result := nil;
   if FCompletionProposal.CompletionColumnIndex <  FCompletionProposal.Columns.Count then

--- a/Source/BCEditor.Editor.LeftMargin.pas
+++ b/Source/BCEditor.Editor.LeftMargin.pas
@@ -10,10 +10,6 @@ uses
 type
   TBCEditorLeftMargin = class(TPersistent)
   type
-    TGetTextEvent = procedure(ASender: TObject; ALine: Integer; var AText: string) of object;
-    TPaintEvent = procedure(ASender: TObject; ALine: Integer; X, Y: Integer) of object;
-    TClickEvent = procedure(ASender: TObject; AButton: TMouseButton; X, Y, ALine: Integer; AMark: TBCEditorMark) of object;
-
     TColors = class(TPersistent)
     strict private
       FBackground: TColor;
@@ -61,12 +57,9 @@ type
     TMarks = class(TPersistent)
     type
       TPanel = class(TPersistent)
-      type
-        TOptions = set of TBCEditorLeftMarginBookMarkPanelOption;
-
       strict private
         FOnChange: TNotifyEvent;
-        FOptions: TOptions;
+        FOptions: TBCEditorLeftMarginBookMarkPanelOptions;
         FVisible: Boolean;
         FWidth: Integer;
         procedure DoChange;
@@ -76,7 +69,7 @@ type
         constructor Create;
         procedure Assign(ASource: TPersistent); override;
       published
-        property Options: TOptions read FOptions write FOptions default [bpoToggleBookmarkByClick];
+        property Options: TBCEditorLeftMarginBookMarkPanelOptions read FOptions write FOptions default [bpoToggleBookmarkByClick];
         property Visible: Boolean read FVisible write SetVisible default True;
         property Width: Integer read FWidth write SetWidth default 20;
         property OnChange: TNotifyEvent read FOnChange write FOnChange;
@@ -107,18 +100,16 @@ type
     end;
 
     TLineNumbers = class(TPersistent)
-    type
-      TOptions = set of TBCEditorLeftMarginLineNumberOption;
     strict private
       FAutosizeDigitCount: Integer;
       FDigitCount: Integer;
       FOnChange: TNotifyEvent;
-      FOptions: TOptions;
+      FOptions: TBCEditorLeftMarginLineNumberOptions;
       FStartFrom: Integer;
       FVisible: Boolean;
       procedure DoChange;
       procedure SetDigitCount(AValue: Integer);
-      procedure SetOptions(const AValue: TOptions);
+      procedure SetOptions(const AValue: TBCEditorLeftMarginLineNumberOptions);
       procedure SetStartFrom(const AValue: Integer);
       procedure SetVisible(const AValue: Boolean);
     public
@@ -128,7 +119,7 @@ type
       property AutosizeDigitCount: Integer read FAutosizeDigitCount write FAutosizeDigitCount;
     published
       property DigitCount: Integer read FDigitCount write SetDigitCount default 4;
-      property Options: TOptions read FOptions write SetOptions default [lnoIntens];
+      property Options: TBCEditorLeftMarginLineNumberOptions read FOptions write SetOptions default [lnoIntens];
       property StartFrom: Integer read FStartFrom write SetStartFrom default 1;
       property Visible: Boolean read FVisible write SetVisible default True;
       property OnChange: TNotifyEvent read FOnChange write FOnChange;
@@ -468,7 +459,7 @@ begin
     Exclude(FOptions, AOption);
 end;
 
-procedure TBCEditorLeftMargin.TLineNumbers.SetOptions(const AValue: TOptions);
+procedure TBCEditorLeftMargin.TLineNumbers.SetOptions(const AValue: TBCEditorLeftMarginLineNumberOptions);
 begin
   if FOptions <> AValue then
   begin

--- a/Source/BCEditor.Editor.MatchingPair.pas
+++ b/Source/BCEditor.Editor.MatchingPair.pas
@@ -10,8 +10,6 @@ uses
 type
   TBCEditorMatchingPair = class(TPersistent)
   type
-    TOptions = set of TBCEditorMatchingPairOption;
-
     TColors = class(TPersistent)
     strict private
       FMatched: TColor;
@@ -31,7 +29,7 @@ type
   strict private
     FColors: TColors;
     FEnabled: Boolean;
-    FOptions: TOptions;
+    FOptions: TBCEditorMatchingPairOptions;
     procedure SetColors(const AValue: TColors);
   public
     constructor Create;
@@ -41,7 +39,7 @@ type
   published
     property Colors: TColors read FColors write SetColors;
     property Enabled: Boolean read FEnabled write FEnabled default True;
-    property Options: TOptions read FOptions write FOptions default DefaultOptions;
+    property Options: TBCEditorMatchingPairOptions read FOptions write FOptions default DefaultOptions;
   end;
 
 implementation {***************************************************************}

--- a/Source/BCEditor.Editor.Replace.pas
+++ b/Source/BCEditor.Editor.Replace.pas
@@ -7,13 +7,11 @@ uses
   BCEditor.Types, BCEditor.Editor.Search;
 
 type
-  TBCEditorReplace = class(TPersistent)
-  type
-    TChangeEvent = procedure(Event: TBCEditorReplaceChanges) of object;
-    TEvent = procedure(ASender: TObject; const APattern, AReplaceText: string; APosition: TBCEditorTextPosition;
+  TChangeEvent = procedure(Event: TBCEditorReplaceChanges) of object;
+  TReplaceEvent = procedure(ASender: TObject; const APattern, AReplaceText: string; APosition: TBCEditorTextPosition;
       var AAction: TBCEditorReplaceAction) of object;
-    TOptions = set of TBCEditorReplaceOption;
 
+  TBCEditorReplace = class(TPersistent)
   strict private const
     DefaultOptions = [roPrompt];
   strict private
@@ -21,7 +19,7 @@ type
     FEndPosition: TBCEditorTextPosition;
     FEngine: TBCEditorSearchEngine;
     FOnChange: TChangeEvent;
-    FOptions: TOptions;
+    FOptions: TBCEditorReplaceOptions;
     FPattern: string;
     FReplaceText: string;
     procedure SetEngine(const AValue: TBCEditorSearchEngine);
@@ -37,7 +35,7 @@ type
     property ReplaceText: string read FReplaceText write FReplaceText;
   published
     property Engine: TBCEditorSearchEngine read FEngine write SetEngine default seNormal;
-    property Options: TOptions read FOptions write FOptions default DefaultOptions;
+    property Options: TBCEditorReplaceOptions read FOptions write FOptions default DefaultOptions;
   end;
 
 implementation

--- a/Source/BCEditor.Editor.RightMargin.pas
+++ b/Source/BCEditor.Editor.RightMargin.pas
@@ -10,8 +10,6 @@ uses
 type
   TBCEditorRightMargin = class(TPersistent)
   type
-    TOptions = set of TBCEditorRightMarginOption;
-
     TColors = class(TPersistent)
     strict private
       FEdge: TColor;
@@ -35,7 +33,7 @@ type
     FMouseOver: Boolean;
     FMoving: Boolean;
     FOnChange: TNotifyEvent;
-    FOptions: TOptions;
+    FOptions: TBCEditorRightMarginOptions;
     FPosition: Integer;
     FVisible: Boolean;
     procedure DoChange;
@@ -53,7 +51,7 @@ type
   published
     property Colors: TBCEditorRightMargin.TColors read FColors write SetColors;
     property Cursor: TCursor read FCursor write FCursor default crHSplit;
-    property Options: TOptions read FOptions write FOptions default [rmoMouseMove, rmoShowMovingHint];
+    property Options: TBCEditorRightMarginOptions read FOptions write FOptions default [rmoMouseMove, rmoShowMovingHint];
     property Position: Integer read FPosition write SetPosition default 80;
     property Visible: Boolean read FVisible write SetVisible default True;
     property OnChange: TNotifyEvent read FOnChange write SetOnChange;

--- a/Source/BCEditor.Editor.Scroll.pas
+++ b/Source/BCEditor.Editor.Scroll.pas
@@ -10,9 +10,6 @@ uses
 type
   TBCEditorScroll = class(TPersistent)
   type
-    TEvent = procedure(ASender: TObject; AScrollBar: TScrollBarKind) of object;
-    TOptions = set of TBCEditorScrollOption;
-
     THint = class(TPersistent)
     strict private
       FFormat: TBCEditorScrollHintFormat;
@@ -30,12 +27,12 @@ type
     FIndicator: TBCEditorGlyph;
     FMaxWidth: Integer;
     FOnChange: TNotifyEvent;
-    FOptions: TOptions;
+    FOptions: TBCEditorScrollOptions;
     procedure DoChange;
     procedure SetHint(const AValue: TBCEditorScroll.THint);
     procedure SetIndicator(const AValue: TBCEditorGlyph);
     procedure SetOnChange(AValue: TNotifyEvent);
-    procedure SetOptions(const AValue: TOptions);
+    procedure SetOptions(const AValue: TBCEditorScrollOptions);
   public
     constructor Create;
     destructor Destroy; override;
@@ -44,7 +41,7 @@ type
   published
     property Hint: TBCEditorScroll.THint read FHint write SetHint;
     property Indicator: TBCEditorGlyph read FIndicator write SetIndicator;
-    property Options: TOptions read FOptions write SetOptions default DefaultOptions;
+    property Options: TBCEditorScrollOptions read FOptions write SetOptions default DefaultOptions;
     property OnChange: TNotifyEvent read FOnChange write SetOnChange;
   end;
 
@@ -136,7 +133,7 @@ begin
     Exclude(FOptions, AOption);
 end;
 
-procedure TBCEditorScroll.SetOptions(const AValue: TOptions);
+procedure TBCEditorScroll.SetOptions(const AValue: TBCEditorScrollOptions);
 begin
   if FOptions <> AValue then
   begin

--- a/Source/BCEditor.Editor.Search.pas
+++ b/Source/BCEditor.Editor.Search.pas
@@ -11,7 +11,6 @@ type
   TBCEditorSearch = class(TPersistent)
   public type
     TChangeEvent = procedure(Event: TBCEditorSearchEvent) of object;
-    TOptions = set of TBCEditorSearchOption;
 
     THighlighter = class(TPersistent)
     type
@@ -53,11 +52,6 @@ type
 
     TMap = class(TPersistent)
     type
-      TOption = (
-        moShowActiveLine
-      );
-      TOptions = set of TBCEditorSearch.TMap.TOption;
-
       TColors = class(TPersistent)
       strict private
         FActiveLine: TColor;
@@ -84,14 +78,14 @@ type
       FColors: TColors;
       FCursor: TCursor;
       FOnChange: TChangeEvent;
-      FOptions: TBCEditorSearch.TMap.TOptions;
+      FOptions: TBCEditorSearchMapOptions;
       FVisible: Boolean;
       FWidth: Integer;
       procedure DoChange;
       procedure SetAlign(const AValue: TBCEditorSearchMapAlign);
       procedure SetColors(const AValue: TColors);
       procedure SetOnChange(AValue: TChangeEvent);
-      procedure SetOptions(const AValue: TMap.TOptions);
+      procedure SetOptions(const AValue: TBCEditorSearchMapOptions);
       procedure SetVisible(AValue: Boolean);
       procedure SetWidth(AValue: Integer);
     public
@@ -103,7 +97,7 @@ type
       property Align: TBCEditorSearchMapAlign read FAlign write SetAlign default saRight;
       property Colors: TColors read FColors write SetColors;
       property Cursor: TCursor read FCursor write FCursor default crArrow;
-      property Options: TBCEditorSearch.TMap.TOptions read FOptions write SetOptions default DefaultOptions;
+      property Options: TBCEditorSearchMapOptions read FOptions write SetOptions default DefaultOptions;
       property Visible: Boolean read FVisible write SetVisible default False;
       property Width: Integer read FWidth write SetWidth default 5;
       property OnChange: TChangeEvent read FOnChange write SetOnChange;
@@ -139,7 +133,7 @@ type
     FInSelection: TInSelection;
     FMap: TMap;
     FOnChange: TChangeEvent;
-    FOptions: TOptions;
+    FOptions: TBCEditorSearchOptions;
     FPattern: string;
     FVisible: Boolean;
     FWholeWordsOnly: Boolean;
@@ -167,7 +161,7 @@ type
     property Highlighter: THighlighter read FHighlighter write SetHighlighter;
     property InSelection: TInSelection read FInSelection write SetInSelection;
     property Map: TMap read FMap write SetMap;
-    property Options: TOptions read FOptions write FOptions default DefaultOptions;
+    property Options: TBCEditorSearchOptions read FOptions write FOptions default DefaultOptions;
     property WholeWordsOnly: Boolean read FWholeWordsOnly write SetWholeWordsOnly default False;
   end;
 
@@ -407,7 +401,7 @@ begin
   FColors.OnChange := FOnChange;
 end;
 
-procedure TBCEditorSearch.TMap.SetOptions(const AValue: TMap.TOptions);
+procedure TBCEditorSearch.TMap.SetOptions(const AValue: TBCEditorSearchMapOptions);
 begin
   if FOptions <> AValue then
   begin

--- a/Source/BCEditor.Editor.Selection.pas
+++ b/Source/BCEditor.Editor.Selection.pas
@@ -10,8 +10,6 @@ uses
 type
   TBCEditorSelection = class(TPersistent)
   type
-    TOptions = set of TBCEditorSelectionOption;
-
     TColors = class(TPersistent)
     strict private
       FBackground: TColor;
@@ -32,9 +30,9 @@ type
     DefaultOptions = [soTermsCaseSensitive];
   strict private
     FColors: TBCEditorSelection.TColors;
-    FOptions: TOptions;
+    FOptions: TBCEditorSelectionOptions;
     procedure SetColors(const AValue: TColors);
-    procedure SetOptions(AValue: TOptions);
+    procedure SetOptions(AValue: TBCEditorSelectionOptions);
   public
     constructor Create;
     destructor Destroy; override;
@@ -42,7 +40,7 @@ type
     procedure SetOption(const AOption: TBCEditorSelectionOption; const AEnabled: Boolean);
   published
     property Colors: TBCEditorSelection.TColors read FColors write SetColors;
-    property Options: TOptions read FOptions write SetOptions default DefaultOptions;
+    property Options: TBCEditorSelectionOptions read FOptions write SetOptions default DefaultOptions;
   end;
 
 implementation {***************************************************************}
@@ -132,7 +130,7 @@ begin
     Exclude(FOptions, AOption);
 end;
 
-procedure TBCEditorSelection.SetOptions(AValue: TOptions);
+procedure TBCEditorSelection.SetOptions(AValue: TBCEditorSelectionOptions);
 begin
   if FOptions <> AValue then
     FOptions := AValue;

--- a/Source/BCEditor.Editor.SpecialChars.pas
+++ b/Source/BCEditor.Editor.SpecialChars.pas
@@ -10,8 +10,6 @@ uses
 type
   TBCEditorSpecialChars = class(TPersistent)
   type
-    TOptions = set of TBCEditorSpecialCharsOption;
-
     TSelection = class(TPersistent)
     strict private
       FColor: TColor;
@@ -55,7 +53,7 @@ type
     FColor: TColor;
     FEndOfLine: TEndOfLine;
     FOnChange: TNotifyEvent;
-    FOptions: TOptions;
+    FOptions: TBCEditorSpecialCharsOptions;
     FSelection: TSelection;
     FStyle: TBCEditorSpecialCharsStyle;
     FVisible: Boolean;
@@ -63,7 +61,7 @@ type
     procedure SetColor(const AValue: TColor);
     procedure SetEndOfLine(const AValue: TEndOfLine);
     procedure SetOnChange(const AValue: TNotifyEvent);
-    procedure SetOptions(AValue: TOptions);
+    procedure SetOptions(AValue: TBCEditorSpecialCharsOptions);
     procedure SetSelection(const AValue: TSelection);
     procedure SetStyle(const AValue: TBCEditorSpecialCharsStyle);
     procedure SetVisible(const AValue: Boolean);
@@ -75,7 +73,7 @@ type
   published
     property Color: TColor read FColor write SetColor default clWindowText;
     property EndOfLine: TBCEditorSpecialChars.TEndOfLine read FEndOfLine write SetEndOfLine;
-    property Options: TOptions read FOptions write SetOptions default [scoMiddleColor];
+    property Options: TBCEditorSpecialCharsOptions read FOptions write SetOptions default [scoMiddleColor];
     property Selection: TSelection read FSelection write SetSelection;
     property Style: TBCEditorSpecialCharsStyle read FStyle write SetStyle default DefaultStyle;
     property Visible: Boolean read FVisible write SetVisible default False;
@@ -261,7 +259,7 @@ begin
     Exclude(FOptions, AOption);
 end;
 
-procedure TBCEditorSpecialChars.SetOptions(AValue: TOptions);
+procedure TBCEditorSpecialChars.SetOptions(AValue: TBCEditorSpecialCharsOptions);
 begin
   if FOptions <> AValue then
   begin

--- a/Source/BCEditor.Editor.Tabs.pas
+++ b/Source/BCEditor.Editor.Tabs.pas
@@ -8,26 +8,24 @@ uses
 
 type
   TBCEditorTabs = class(TPersistent)
-  type
-    TOptions = set of TBCEditorTabOption;
   strict private const
     DefaultOptions = [toColumns, toSelectedBlockIndent];
     DefaultWantTabs = True;
     DefaultWidth = 2;
   strict private
     FOnChange: TNotifyEvent;
-    FOptions: TOptions;
+    FOptions: TBCEditorTabOptions;
     FWantTabs: Boolean;
     FWidth: Integer;
     procedure DoChange;
-    procedure SetOptions(const AValue: TOptions);
+    procedure SetOptions(const AValue: TBCEditorTabOptions);
     procedure SetWantTabs(const AValue: Boolean);
     procedure SetWidth(const AValue: Integer);
   public
     constructor Create;
     procedure Assign(ASource: TPersistent); override;
   published
-    property Options: TOptions read FOptions write SetOptions default DefaultOptions;
+    property Options: TBCEditorTabOptions read FOptions write SetOptions default DefaultOptions;
     property WantTabs: Boolean read FWantTabs write SetWantTabs default DefaultWantTabs;
     property Width: Integer read FWidth write SetWidth default DefaultWidth;
     property OnChange: TNotifyEvent read FOnChange write FOnChange;
@@ -66,7 +64,7 @@ begin
     FOnChange(Self);
 end;
 
-procedure TBCEditorTabs.SetOptions(const AValue: TOptions);
+procedure TBCEditorTabs.SetOptions(const AValue: TBCEditorTabOptions);
 begin
   if FOptions <> AValue then
   begin

--- a/Source/BCEditor.Editor.TokenInfo.pas
+++ b/Source/BCEditor.Editor.TokenInfo.pas
@@ -10,8 +10,6 @@ uses
 type
   TBCEditorTokenInfo = class(TPersistent)
   type
-    TOptions = set of TBCEditorTokenInfoOption;
-
     TTitle = class(TPersistent)
     type
       TColors = class(TPersistent)
@@ -61,7 +59,7 @@ type
     FEnabled: Boolean;
     FFont: TFont;
     FHeight: Integer;
-    FOptions: TBCEditorTokenInfo.TOptions;
+    FOptions: TBCEditorTokenInfoOptions;
     FTitle: TTitle;
     FWidth: Integer;
     procedure SetFont(const AValue: TFont);
@@ -75,7 +73,7 @@ type
     property Enabled: Boolean read FEnabled write FEnabled default False;
     property Font: TFont read FFont write SetFont;
     property Height: Integer read FHeight write FHeight default 0;
-    property Options: TBCEditorTokenInfo.TOptions read FOptions write FOptions default DefaultOptions;
+    property Options: TBCEditorTokenInfoOptions read FOptions write FOptions default DefaultOptions;
     property Title: TTitle read FTitle write FTitle;
     property Width: Integer read FWidth write FWidth default 0;
   end;

--- a/Source/BCEditor.Editor.pas
+++ b/Source/BCEditor.Editor.pas
@@ -20,8 +20,6 @@ uses
 
 type
   TCustomBCEditor = class(TCustomControl)
-  type
-    TUndoOptions = set of TBCEditorUndoOption;
   strict private type
     TBCEditorLines = class(BCEditor.Lines.TBCEditorLines);
     TBCEditorReplace = class(BCEditor.Editor.Replace.TBCEditorReplace);
@@ -184,12 +182,12 @@ type
     FOnAfterLinePaint: TBCEditorLinePaintEvent;
     FOnAfterMarkPanelPaint: TBCEditorMarkPanelPaintEvent;
     FOnAfterMarkPlaced: TNotifyEvent;
-    FOnBeforeCompletionProposalExecute: TBCEditorCompletionProposal.TEvent;
+    FOnBeforeCompletionProposalExecute: TCompletionEvent;
     FOnBeforeDeleteMark: TBCEditorMarkEvent;
     FOnBeforeMarkPanelPaint: TBCEditorMarkPanelPaintEvent;
     FOnBeforeMarkPlaced: TBCEditorMarkEvent;
     FOnBeforeTokenInfoExecute: TBCEditorTokenInfoEvent;
-    FOnCaretChanged: TBCEditorCaret.TChangedEvent;
+    FOnCaretChanged: TCaretChangedEvent;
     FOnChainCaretMoved: TNotifyEvent;
     FOnChainLinesCleared: TNotifyEvent;
     FOnChainLinesDeleted: TBCEditorLines.TChangeEvent;
@@ -198,22 +196,22 @@ type
     FOnChange: TNotifyEvent;
     FOnCommandProcessed: TBCEditorProcessCommandEvent;
     FOnCompletionProposalCanceled: TNotifyEvent;
-    FOnCompletionProposalSelected: TBCEditorCompletionProposal.TSelectedEvent;
+    FOnCompletionProposalSelected: TSelectedEvent;
     FOnContextHelp: TBCEditorContextHelpEvent;
     FOnCreateFileStream: TBCEditorCreateFileStreamEvent;
     FOnCustomLineColors: TBCEditorCustomLineColorsEvent;
     FOnCustomTokenAttribute: TBCEditorCustomTokenAttributeEvent;
     FOnDropFiles: TBCEditorDropFilesEvent;
     FOnKeyPressW: TBCEditorKeyPressWEvent;
-    FOnLeftMarginClick: TBCEditorLeftMargin.TClickEvent;
+    FOnLeftMarginClick: TMarginClickEvent;
     FOnMarkPanelLinePaint: TBCEditorMarkPanelLinePaintEvent;
     FOnModified: TNotifyEvent;
     FOnPaint: TBCEditorPaintEvent;
     FOnProcessCommand: TBCEditorProcessCommandEvent;
     FOnProcessUserCommand: TBCEditorProcessCommandEvent;
-    FOnReplaceText: TBCEditorReplace.TEvent;
+    FOnReplaceText: TReplaceEvent;
     FOnRightMarginMouseUp: TNotifyEvent;
-    FOnScroll: TBCEditorScroll.TEvent;
+    FOnScroll: TScrollEvent;
     FOnSelectionChanged: TNotifyEvent;
     FOptions: TBCEditorOptions;
     FOriginalLines: TBCEditorLines;
@@ -529,7 +527,6 @@ type
     procedure FreeTokenInfoPopupWindow;
     function GetBookmark(const AIndex: Integer; var ATextPosition: TBCEditorTextPosition): Boolean;
     function GetColorsFileName(const AFileName: string): string;
-    function GetHighlighterFileName(const AFileName: string): string;
     function GetReadOnly: Boolean; virtual;
     function GetRows(): TRows;
     function GetSelLength: Integer;
@@ -614,31 +611,31 @@ type
     property OnAfterLinePaint: TBCEditorLinePaintEvent read FOnAfterLinePaint write FOnAfterLinePaint;
     property OnAfterMarkPanelPaint: TBCEditorMarkPanelPaintEvent read FOnAfterMarkPanelPaint write FOnAfterMarkPanelPaint;
     property OnAfterMarkPlaced: TNotifyEvent read FOnAfterMarkPlaced write FOnAfterMarkPlaced;
-    property OnBeforeCompletionProposalExecute: TBCEditorCompletionProposal.TEvent read FOnBeforeCompletionProposalExecute write FOnBeforeCompletionProposalExecute;
+    property OnBeforeCompletionProposalExecute: TCompletionEvent read FOnBeforeCompletionProposalExecute write FOnBeforeCompletionProposalExecute;
     property OnBeforeDeleteMark: TBCEditorMarkEvent read FOnBeforeDeleteMark write FOnBeforeDeleteMark;
     property OnBeforeMarkPanelPaint: TBCEditorMarkPanelPaintEvent read FOnBeforeMarkPanelPaint write FOnBeforeMarkPanelPaint;
     property OnBeforeMarkPlaced: TBCEditorMarkEvent read FOnBeforeMarkPlaced write FOnBeforeMarkPlaced;
     property OnBeforeTokenInfoExecute: TBCEditorTokenInfoEvent read FOnBeforeTokenInfoExecute write FOnBeforeTokenInfoExecute;
-    property OnCaretChanged: TBCEditorCaret.TChangedEvent read FOnCaretChanged write FOnCaretChanged;
+    property OnCaretChanged: TCaretChangedEvent read FOnCaretChanged write FOnCaretChanged;
     property OnChange: TNotifyEvent read FOnChange write FOnChange;
     property OnCommandProcessed: TBCEditorProcessCommandEvent read FOnCommandProcessed write FOnCommandProcessed;
     property OnCompletionProposalCanceled: TNotifyEvent read FOnCompletionProposalCanceled write FOnCompletionProposalCanceled;
-    property OnCompletionProposalSelected: TBCEditorCompletionProposal.TSelectedEvent read FOnCompletionProposalSelected write FOnCompletionProposalSelected;
+    property OnCompletionProposalSelected: TSelectedEvent read FOnCompletionProposalSelected write FOnCompletionProposalSelected;
     property OnContextHelp: TBCEditorContextHelpEvent read FOnContextHelp write FOnContextHelp;
     property OnCreateFileStream: TBCEditorCreateFileStreamEvent read FOnCreateFileStream write FOnCreateFileStream;
     property OnCustomLineColors: TBCEditorCustomLineColorsEvent read FOnCustomLineColors write FOnCustomLineColors;
     property OnCustomTokenAttribute: TBCEditorCustomTokenAttributeEvent read FOnCustomTokenAttribute write FOnCustomTokenAttribute;
     property OnDropFiles: TBCEditorDropFilesEvent read FOnDropFiles write FOnDropFiles;
     property OnKeyPress: TBCEditorKeyPressWEvent read FOnKeyPressW write FOnKeyPressW;
-    property OnLeftMarginClick: TBCEditorLeftMargin.TClickEvent read FOnLeftMarginClick write FOnLeftMarginClick;
+    property OnLeftMarginClick: TMarginClickEvent read FOnLeftMarginClick write FOnLeftMarginClick;
     property OnMarkPanelLinePaint: TBCEditorMarkPanelLinePaintEvent read FOnMarkPanelLinePaint write FOnMarkPanelLinePaint;
     property OnModified: TNotifyEvent read FOnModified write FOnModified;
     property OnPaint: TBCEditorPaintEvent read FOnPaint write FOnPaint;
     property OnProcessCommand: TBCEditorProcessCommandEvent read FOnProcessCommand write FOnProcessCommand;
     property OnProcessUserCommand: TBCEditorProcessCommandEvent read FOnProcessUserCommand write FOnProcessUserCommand;
-    property OnReplaceText: TBCEditorReplace.TEvent read FOnReplaceText write FOnReplaceText;
+    property OnReplaceText: TReplaceEvent read FOnReplaceText write FOnReplaceText;
     property OnRightMarginMouseUp: TNotifyEvent read FOnRightMarginMouseUp write FOnRightMarginMouseUp;
-    property OnScroll: TBCEditorScroll.TEvent read FOnScroll write FOnScroll;
+    property OnScroll: TScrollEvent read FOnScroll write FOnScroll;
     property OnSelectionChanged: TNotifyEvent read FOnSelectionChanged write FOnSelectionChanged;
     property Options: TBCEditorOptions read FOptions write SetOptions default DefaultOptions;
     property Rows: TRows read GetRows;
@@ -682,6 +679,7 @@ type
     procedure ExportToHTML(const AFileName: string; const ACharSet: string = ''; AEncoding: TEncoding = nil); overload;
     procedure ExportToHTML(AStream: TStream; const ACharSet: string = ''; AEncoding: TEncoding = nil); overload;
     procedure FindAll;
+    function GetHighlighterFileName(const AFileName: string): string;
     function GetWordAtPixels(const X, Y: Integer): string; deprecated 'Use WordAt[ClientToText()]'; // 2017-03-16
     procedure HookEditorLines(ALines: TBCEditorLines; AUndo, ARedo: TBCEditorLines.TUndoList);
     procedure LoadFromFile(const AFileName: string; AEncoding: TEncoding = nil); deprecated 'Use Lines.LoadFromFile'; // 2017-03-10
@@ -3129,7 +3127,7 @@ var
   LControl: TWinControl;
   LCurrentInput: string;
   LIndex: Integer;
-  LItem: TBCEditorCompletionProposal.TItems.TItem;
+  LItem: TCompletionItems.TItem;
   LItems: TStrings;
   LPoint: TPoint;
 begin
@@ -6449,7 +6447,7 @@ var
 
 var
   LFoldRegion: TBCEditorCodeFolding.TRegion;
-  LFoldRegionItem: TBCEditorCodeFolding.TRegion.TItem;
+  LFoldRegionItem: TRegionItem;
   LIndex1: Integer;
   LIndex2: Integer;
   LLineBeginPos: PChar;
@@ -6510,7 +6508,7 @@ function TCustomBCEditor.IsKeywordAtPositionOrAfter(const APosition: TBCEditorTe
 var
   LCaretPosition: TBCEditorTextPosition;
   LFoldRegion: TBCEditorCodeFolding.TRegion;
-  LFoldRegionItem: TBCEditorCodeFolding.TRegion.TItem;
+  LFoldRegionItem: TRegionItem;
   LIndex1: Integer;
   LIndex2: Integer;
   LLineBeginPos: PChar;
@@ -10657,7 +10655,7 @@ var
     LCodeFoldingRange: TBCEditorCodeFolding.TRanges.TRange;
     LIndex: Integer;
     LLineTempPos: PChar;
-    LRegionItem: TBCEditorCodeFolding.TRegion.TItem;
+    LRegionItem: TRegionItem;
     LSkipIfFoundAfterOpenToken: Boolean;
     LTokenEndPos: PChar;
     LTokenFollowEndPos: PChar;
@@ -10940,10 +10938,11 @@ var
     LTextBeginPos: PChar;
     LTextEndPos: PChar;
     LTextPos: PChar;
-    LRegionItem: TBCEditorCodeFolding.TRegion.TItem;
+    LRegionItem: TRegionItem;
     LTokenAttributes: string;
     LTokenAttributesBeginPos: PChar;
     LTokenName: string;
+    LRegion: BCEditor.Editor.CodeFolding.TBCEditorCodeFolding.TRegion;
   begin
     LText := Lines.Text;
     LTextBeginPos := @LText[1];
@@ -10985,12 +10984,15 @@ var
           LCloseToken := '</' + LTokenName + '>';
 
           if (LTextPos^ = '>') and (LTextPos^ <> '/') then
-            if not FHighlighter.CodeFoldingRegions[0].Contains(LOpenToken, LCloseToken) then { First (0) is the default range }
+          begin
+            LRegion := FHighlighter.CodeFoldingRegions[0];
+            if not LRegion.Contains(LOpenToken, LCloseToken) then { First (0) is the default range }
             begin
-              LRegionItem := FHighlighter.CodeFoldingRegions[0].Add(LOpenToken, LCloseToken);
+              LRegionItem := LRegion.Add(LOpenToken, LCloseToken);
               LRegionItem.BreakCharFollows := False;
               LAdded := True;
             end;
+          end;
         end;
       end;
       Inc(LTextPos);

--- a/Source/BCEditor.Lines.pas
+++ b/Source/BCEditor.Lines.pas
@@ -10,7 +10,6 @@ uses
 type
   TBCEditorLines = class(TStrings)
   protected type
-    TChangeEvent = procedure(Sender: TObject; const Line: Integer) of object;
     TCompare = function(Lines: TBCEditorLines; Line1, Line2: Integer): Integer;
 
     TOption = (loColumnTabs, loTrimTrailingSpaces, loTrimTrailingLines,
@@ -80,6 +79,8 @@ type
       Text: string;
     end;
 
+  public type
+    TChangeEvent = procedure(Sender: TObject; const Line: Integer) of object;
     TUndoList = class(TList<TUndoItem>)
     strict private
       FBlockNumber: Integer;

--- a/Source/BCEditor.Types.pas
+++ b/Source/BCEditor.Types.pas
@@ -6,7 +6,7 @@ uses
   Windows,
   Classes, SysUtils,
   Forms, Graphics, Controls,
-  BCEditor.Consts;
+  BCEditor.Consts, BCEditor.Editor.Marks;
 
 type
   TBCEditorArrayOfString = array of string;
@@ -311,6 +311,32 @@ type
   TBCEditorMinimapIndicatorOption = (ioInvertBlending, ioShowBorder, ioUseBlending);
 
   TBCEditorCodeFoldingHintIndicatorOption = (hioShowBorder, hioShowMark);
+
+  TBCEditorCaretOptions = set of TBCEditorCaretOption;
+  TBCEditorCaretMultiEditOptions = set of TBCEditorCaretMultiEditOption;
+  TBCEditorLeftMarginLineNumberOptions = set of TBCEditorLeftMarginLineNumberOption;
+  TBCEditorMatchingPairOptions = set of TBCEditorMatchingPairOption;
+  TBCEditorSearchOptions = set of TBCEditorSearchOption;
+  TBCEditorSearchMapOptions = set of TBCEditorSearchMapOption;
+  TBCEditorLeftMarginBookMarkPanelOptions = set of TBCEditorLeftMarginBookMarkPanelOption;
+  TBCEditorReplaceOptions = set of TBCEditorReplaceOption;
+  TBCEditorRightMarginOptions = set of TBCEditorRightMarginOption;
+  TBCEditorScrollOptions = set of TBCEditorScrollOption;
+  TBCEditorSelectionOptions = set of TBCEditorSelectionOption;
+  TBCEditorSpecialCharsOptions = set of TBCEditorSpecialCharsOption;
+  TBCEditorTabOptions = set of TBCEditorTabOption;
+  TBCEditorTokenInfoOptions = set of TBCEditorTokenInfoOption;
+  TUndoOptions = set of TBCEditorUndoOption;
+  TBCEditorCompletionProposalOptions = set of TBCEditorCompletionProposalOption;
+  TBCEditorCodeFoldingOptions = set of TBCEditorCodeFoldingOption;
+  TBCEditorCodeFoldingHintIndicatorOptions = set of TBCEditorCodeFoldingHintIndicatorOption;
+  TItemType = (ritUnspecified, ritMultiLineString, ritSingleLineString, ritMultiLineComment, ritSingleLineComment);
+
+  TCaretChangedEvent = procedure(ASender: TObject; X, Y: Integer) of object;
+  TMarginClickEvent = procedure(ASender: TObject; AButton: TMouseButton; X, Y, ALine: Integer; AMark: TBCEditorMark) of object;
+  TScrollEvent = procedure(ASender: TObject; AScrollBar: TScrollBarKind) of object;
+  TSelectedEvent = procedure(Sender: TObject; var ASelectedItem: string) of object;
+  TValidateEvent = procedure(ASender: TObject; Shift: TShiftState; EndToken: Char) of object;
 
   TBCEditorQuadColor = packed record
   case Boolean of


### PR DESCRIPTION
These changes will allow the component to be used in C++ Builder. I have tested the changes with RAD Studio 10.1 Berlin (using a JavaScript file), and whilst the syntax highlighting works there is a strange bug where clicking inside the editor selects all lines from the bottom of the editor up to and including the current line. I am not familiar enough with the component yet to work out why this is happening and would be interested to know if it also happens in a Delphi application - i.e. is it something I have broken as part of these changes?